### PR TITLE
Use host config instead of switch

### DIFF
--- a/frameworks/angular/container/angular.json
+++ b/frameworks/angular/container/angular.json
@@ -66,7 +66,10 @@
               "browserTarget": "container:build:development"
             }
           },
-          "defaultConfiguration": "development"
+          "defaultConfiguration": "development",
+		  "options": {
+			"host": "127.0.0.1"
+		  }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/frameworks/angular/container/package.json
+++ b/frameworks/angular/container/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host=127.0.0.1",
+    "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/frameworks/angular/creating-container.md
+++ b/frameworks/angular/creating-container.md
@@ -15,13 +15,28 @@ npm install @openfin/core openfin-adapter @finos/fdc3 openfin-notifications
 
 ## Modify and add scripts in package.json
 
-The `--host` switch is required for NodeJs v17+ to be able to resolve the Angular server from the OpenFin launch script. (see [https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705](https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705))
-
 ```json
 "scripts": {
-   "start": "ng serve --host=127.0.0.1",
    ...
    "client": "node launch.mjs http://127.0.0.1:4200/assets/platform/manifest.fin.json"
+}
+```
+
+## Modify angular.json
+
+The `host` option is required for NodeJs v17+ to be able to resolve the Angular server from the OpenFin launch script. (see [https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705](https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705))
+
+```json
+"projects": {
+   "container": {
+      "architect": {
+         "serve": {
+            "options": {
+               "host": "127.0.0.1"
+            }
+         }
+      }
+   }
 }
 ```
 

--- a/frameworks/angular/creating-workspace.md
+++ b/frameworks/angular/creating-workspace.md
@@ -15,13 +15,28 @@ npm install @openfin/core @openfin/workspace @openfin/workspace-platform openfin
 
 ## Modify and add scripts in package.json
 
-The `--host` switch is required for NodeJs v17+ to be able to resolve the Angular server from the OpenFin launch script. (see [https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705](https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705))
-
 ```json
 "scripts": {
-   "start": "ng serve --host=127.0.0.1",
    ...
    "client": "node launch.mjs http://127.0.0.1:4200/assets/platform/manifest.fin.json"
+}
+```
+
+## Modify angular.json
+
+The `host` option is required for NodeJs v17+ to be able to resolve the Angular server from the OpenFin launch script. (see [https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705](https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705))
+
+```json
+"projects": {
+   "workspace": {
+      "architect": {
+         "serve": {
+            "options": {
+               "host": "127.0.0.1"
+            }
+         }
+      }
+   }
 }
 ```
 

--- a/frameworks/angular/workspace/angular.json
+++ b/frameworks/angular/workspace/angular.json
@@ -66,7 +66,10 @@
               "browserTarget": "workspace:build:development"
             }
           },
-          "defaultConfiguration": "development"
+          "defaultConfiguration": "development",
+		  "options": {
+			"host": "127.0.0.1"
+		  }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/frameworks/angular/workspace/package.json
+++ b/frameworks/angular/workspace/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host=127.0.0.1",
+    "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",


### PR DESCRIPTION
If someone uses `ng serve` to start the server instead of `npm run start` the host is not configured. By setting the value in `angular.json` the `host` setting is used however you launch the app.